### PR TITLE
Prevent interactive commit message prompt

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ async function gitSnapshot(argv) {
   const onCwdOpts = {cwd};
   const onWorktreeOpts = {cwd: worktreePath};
   const authorOpt = author ? ['--author', author] : [];
-  const messageOpt = message ? ['--message', message] : [];
+  const messageOpt = ['--message', message || ' ' ];
   const prefixPath = path.resolve(prefix);
   const forceOpt = force ? '--force' : '';
 


### PR DESCRIPTION
When using git-snapshot with Git on Windows (`git version 2.27.0.windows.1`), the use of `--allow-empty-message` without the `--message` option causes an indefinite hang, as git opens an interactive commit message editor prompt. This results in the snapshot process never completing.

This PR fixes that by providing an empty commit message if the `message` option is not passed.