### PR TITLE
fix: Use --force instead of -f for the worktree remove command

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ async function gitSnapshot(argv) {
   } finally {
     // Remove added worktree.
     if (isAddedWorktree) {
-      await git(['worktree', 'remove', '-f', worktreePath], onCwdOpts);
+      await git(['worktree', 'remove', '--force', worktreePath], onCwdOpts);
       await git(['worktree', 'prune'], onCwdOpts);
     }
 


### PR DESCRIPTION
Using `-f` fails with the following error on a Linux Mint. Using `--force` works as expected.

```
error: unknown switch `f'
usage: git worktree add [<options>] <path> [<commit-ish>]
   or: git worktree list [<options>]
   or: git worktree lock [<options>] <path>
   or: git worktree move <worktree> <new-path>
   or: git worktree prune [<options>]
   or: git worktree remove [<options>] <worktree>
   or: git worktree unlock <path>

    --force               force removing even if the worktree is dirty
```